### PR TITLE
fix an issue with redis when net.LookupIP returns duplicate ips

### DIFF
--- a/internal/redis/node.go
+++ b/internal/redis/node.go
@@ -77,7 +77,7 @@ func NewNode(config *config.Config, logger *slog.Logger, fqdn string) (*Node, er
 		conn:      client.NewClient(&opts),
 		logger:    nodeLogger,
 		fqdn:      fqdn,
-		ips:       ips,
+		ips:       uniqIPs(ips),
 		ipsTime:   now,
 	}
 	return &node, nil
@@ -132,9 +132,22 @@ func (n *Node) RefreshAddrs() error {
 		n.logger.Error("Updating ips cache failed", "error", err)
 		return err
 	}
-	n.ips = ips
+	n.ips = uniqIPs(ips)
 	n.ipsTime = now
 	return nil
+}
+
+// uniqIPs returns a slice of unique ips
+func uniqIPs(ips []net.IP) []net.IP {
+	uniq := map[string]struct{}{}
+	for _, ip := range ips {
+		uniq[string(ip)] = struct{}{}
+	}
+	ret := make([]net.IP, 0, len(uniq))
+	for ip := range uniq {
+		ret = append(ret, []byte(ip))
+	}
+	return ret
 }
 
 // GetIP returns first ip as string


### PR DESCRIPTION
environment: rdsync + redis with patches from redis_patches/* - 3 nodes

error:
```
Jun  5 15:30:16 host1.example rdsync[8375]: time=2024-06-05T15:30:16.218 level=DEBUG msg="Setting quorum replicas to host2.example:6379 host1.example:6379 2.2.2.2:6379 1.1.1.1:6379 1.1.1.1:6379 on host3.example"
Jun  5 15:30:16 host1.example rdsync[8375]: time=2024-06-05T15:30:16.218 level=ERROR msg="Update active nodes: failed to actualize quorum replicas" error="ERR CONFIG SET failed (possibly related to argument 'quorum-replicas') - Unable to set quorum replicas."
Jun  5 15:30:16 host1.example rdsync[8375]: time=2024-06-05T15:30:16.218 level=ERROR msg="Failed to update active nodes in dcs" error="ERR CONFIG SET failed (possibly related to argument 'quorum-replicas') - Unable to set quorum replicas."
```

"1.1.1.1:6379" listed twice in the DEBUG message

this happens if there are similar entries in /etc/hosts
/etc/hosts
```
...
1.1.1.1 host1.example
1.1.1.1   host1.example rdtest1
...
```
so net.LookupIP returns two IPs for host1.example

Redis side:
redis_patches/0004_Add_waitquorum_command.patch
dictAdd fails if the record already exists
```
if (dictAdd(server.quorum_replicas, quorum_replica, NULL) == DICT_ERR) {
*err = "Unable to set quorum replicas.";
```

uniqIPs func was added to fix this issue, I believe it may be useful in an environment where /etc/hosts cannot be edited

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
